### PR TITLE
import GlyphsApp.* for constants to fix #5

### DIFF
--- a/ShowBlackFill.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowBlackFill.glyphsReporter/Contents/Resources/plugin.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from GlyphsApp.plugins import *
+from GlyphsApp import *
 
 class ShowBlackFill(ReporterPlugin):
 


### PR DESCRIPTION
The error reported in #5 is fixed simply by importing the necessary constants. I've added this because I was working on a font where the color background was a great help, so now the plugin should work again with the latest version of Glyphs [works with Version 2.5.2 (1163)].